### PR TITLE
actually fix spotify..

### DIFF
--- a/app/js/require/spotify.js
+++ b/app/js/require/spotify.js
@@ -14,7 +14,9 @@ class spotifyMusicPlayerInterface extends EventEmitter {
   update() {
     try {
       this.isPlaying = execSync("/usr/bin/osascript -e 'tell application \"Spotify\" to player state as string'").includes('playing')
-      this.trackInfo = execSync("/usr/bin/osascript -e 'tell application \"Spotify\" to artist of current track & \" - \" name of current track as string'")
+      var artist = execSync("/usr/bin/osascript -e 'tell application \"Spotify\" to artist of current track as string'")
+      var track = execSync("/usr/bin/osascript -e 'tell application \"Spotify\" to name of current track as string'")
+      this.trackInfo = artist + " - " + track
     } catch (e) {
       this.isPlaying = false
       this.trackInfo = ''


### PR DESCRIPTION
So I added a second commit to my old PR before it was merged that actually ended up breaking it for some reason...

The commit basically unified it to return both artist and track in the same osascript call, and while it worked when ran from the terminal, something makes it not work when it is executed through execSync.

The output is just gone, the playback icon no longer shows and half the bar seems to not load properly. No error message is printed during startup.

I've split them into two separate osascript calls again, and now it works fine.

Running the following from a shell yields `artist - song`, but does not work inside snwe
```
# from terminal
osascript -e 'tell application "Spotify" to artist of current track & " - " & name of current track as string' 

# inside snwe with quote escaping
/usr/bin/osascript -e 'tell application \"Spotify\" to artist of current track & \" - \" & name of current track as string' 
```

This commit reverts the unification and splits it into two commands, which make it work.
I don't have enough experience with node or javascript to actually debug this issue.